### PR TITLE
Pinning python Kubernetes client to version 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can do that by ssh-ing into the machine and then doing:
 
 ```
 sudo zypper in python-pip
-sudo pip install kubernetes
+sudo pip install kubernetes==1.0.2
 ```
 
 ### Checkout the kubernetes module (optional)


### PR DESCRIPTION
Looks like this module is not compatible with version 2.0.0 and the upcoming 3.0.0 release.